### PR TITLE
Fix for 'Pin <x> in use'

### DIFF
--- a/lib/sx126x.py
+++ b/lib/sx126x.py
@@ -343,7 +343,7 @@ class SX126X:
             ASSERT(state)
 
         return self.readData(data, len_)
-        
+
     def transmitDirect(self, frf=0):
         state = ERR_NONE
         if frf != 0:


### PR DESCRIPTION
As described in https://github.com/ehong-tl/micropySX126X/issues/16
Tested on RP2040 with Seeed SX1262.

```
from sx1262 import SX1262
import time, board, busio, digitalio

sx = SX1262(
    spi_bus=1,
    clk=board.GP14,   # SCK
    mosi=board.GP15,  # MOSI
    miso=board.GP28,  # MISO
    cs=board.GP13,    # NSS
    irq=board.GP16,   # DIO1
    rst=board.GP7,   # RESET
    gpio=board.GP18   # BUSY
)

sx.begin(freq=906.875000, bw=250.0, sf=11, cr=5, syncWord=0x12, # 2b - Meshtastic
         power=-5, currentLimit=120.0, preambleLength=16,
         implicit=False, implicitLen=0xFF,
         crcOn=False, txIq=False, rxIq=False,
         tcxoVoltage=1.7, useRegulatorLDO=False, blocking=True)

while True:
    msg, err = sx.recv()
    if len(msg) > 0:
        error = SX1262.STATUS[err]
        print(msg)
        if error != 'ERR_NONE': print(error)
```